### PR TITLE
removed link for people who don't have one

### DIFF
--- a/src/student-modal/StudentModal.js
+++ b/src/student-modal/StudentModal.js
@@ -52,7 +52,12 @@ class StudentModal extends Component {
                                 <a target='_blank' href={this.state.currentStudent.linkedin}><i class="fab fa-linkedin student__links"></i></a>
                                 <a  href={this.state.currentStudent.email}><i class="far fa-envelope student__links"></i></a>
                                 <a target='_blank' href={this.state.currentStudent.personal_website}><i class="fas fa-user-circle student__links"></i></a>
-                                <a target='_blank' href={this.state.currentStudent.other_website}><i class="fas fa-globe-americas student__links"></i></a>
+                                {
+                                    this.state.currentStudent.other_website === '' ?
+                                    null
+                                    :
+                                    <a target='_blank' href={this.state.currentStudent.other_website}><i class="fas fa-globe-americas student__links"></i></a>
+                                }
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
# Description

Please include a summary of the change. List any dependencies that are required for this change.

Fixes #25 

```
git fetch --all
git checkout rm-remove-blank-links
```

1. load up site
1. check that people who do not have an other link do not have that icon displayed on their modal
1. find someone who does have that link (Rachel has one) and see that their link is still displayed

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

